### PR TITLE
🔖 Ready to release v1.0.0 | 03/23

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,11 +3,11 @@
   "version": "1.0.0",
   "description": "A restful API used for saving users' start page links.",
   "scripts": {
-    "start": "yarn run build && node dist/lib/server.js",
+    "start:from-build": "yarn run build && node dist/lib/server.js",
     "build": "rm -rf ./dist/ && babel src -d dist/lib --ignore 'src/tests/' && yarn build:knexConfig",
     "build:knexConfig": "babel ./knexfile.js -d dist",
     "babel-node": "./node_modules/@babel/node/bin/babel-node.js",
-    "start:es6": "NODE_ENV=production yarn babel-node src/server.js",
+    "start": "NODE_ENV=production yarn babel-node src/server.js",
     "dev": "NODE_ENV=development nodemon --exec babel-node src/server.js",
     "knex": "yarn babel-node ./node_modules/knex/bin/cli.js",
     "coveralls": "./node_modules/coveralls/bin/coveralls.js",


### PR DESCRIPTION
Updated start script in order to run yarn start by default on heroku, ready for a v1.0.0 release!

Note: having trouble with building the project through babel: getting an EOD error with the migrations folder. Will work on fixing for future releases, but for now, using the current start script.